### PR TITLE
Introduce improvements based on feedback from review session

### DIFF
--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -375,7 +375,7 @@ Select one:
 
 - Current stable version
 - Previous stable version
-- Another specific version of stable Rust
+- Some other specific version of stable Rust
 - Beta release
 - Latest nightly
 - A specific version of nightly
@@ -461,6 +461,7 @@ Select all that apply:
 - To help test the nightly version for bugs
 - For testing in CI
 - A dependency I use requires it
+- Other
 
 > **justification**
 >
@@ -476,6 +477,7 @@ Select all that apply:
 - To adopt stabilized language features as early as possible
 - To help test the beta version for bugs
 - For testing in CI
+- Other
 
 > **justification**
 >

--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -369,12 +369,13 @@ Select all that apply:
 - embedded platforms (bare metal)
 - other
 
-### Which version(s) of Rust do you use for your applications?
+### Which version(s) of Rust do you use?
 
 Select one:
 
 - Current stable version
 - Previous stable version
+- Another specific version of stable Rust
 - Beta release
 - Latest nightly
 - A specific version of nightly

--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -453,14 +453,33 @@ Select one:
 
 ### If you use nightly, why?
 
-Select one:
+Select all that apply:
 
 - I don't use nightly
 - Out of habit
 - For a particular language feature or set of language features I need
+- To help test the nightly version for bugs
+- For testing in CI
 - A dependency I use requires it
 
-> TODO look at other common answers from previous surveys
+> **justification**
+>
+> We'd like to know what are the common reasons people use nightly
+> so that we can better understand where testers are coming from.
+
+### If you use beta, why?
+
+Select all that apply:
+
+- I don't use beta
+- Out of habit
+- To adopt stabilized language features as early as possible
+- To help test the beta version for bugs
+- For testing in CI
+
+> **justification**
+>
+> Same justification as the question about nightly but for beta.
 
 ### What ways do you install Rust?
 

--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -279,23 +279,10 @@ Select one:
 > This can be useful demographic information as a proxy for how "important" Rust is
 > in someone's technical life.
 >
-> **TODO** should we rephrase this to not rely on calendar time? Someone who only
-> programs once a week but always uses Rust is different than someone who programs
-> daily but only uses Rust once a week
->
-> **TODO** There are a few options on how to approach this.
->
-> One is to add a reference period to the question:
-> e.g. In a typical week/month, how often do you use Rust?
-> Answers: numerical/time ranges
->
-> Another approach is to be more vague:
-> e.g. In a typical week/month, how often do you use Rust?
-> Answers: Always, Somtimes, Rarely, Never
->
-> Or we can be more open-ended:
-> e.g. In a typical week, approximately how many hours do you sepnd using Rust?
-> [Fill in number]
+> We deliberately use calendar time for this question to gauge how "serious" the
+> programmers use of Rust is. This does mean that we will group together, for example,
+> those who program once a week but always in Rust and those who program daily but
+> use Rust once a week.
 
 ### How would you rate the learning of these concepts?
 


### PR DESCRIPTION
This PR makes three improvements (all found in separate commits):
* Removes a TODO that questioned the use of calendar time in a question (and adds justification for using calendar time)
* Improves a question about which version of Rust people use by adding an option for a specific stable version.
* Improve question about why people use nightly (by adding options for use in CI and for help testing) and add the same question for beta.