### PR TITLE
Add some options about compiler errors and error messages to aspect ratings

### DIFF
--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -385,7 +385,7 @@ Aspects:
 - Compile times
 - Binary size
 - Disk space (e.g., the size of `target` folder)
-- Lack of bugs in the compiler (i.e., ICEs a.k.a. internal compiler errors, miscompilations, etc.)
+- Bugs in the compiler (i.e., ICEs a.k.a. internal compiler errors, miscompilations, etc.)
 - Compilation error messages
 - IDE experience
 - Available tools and support


### PR DESCRIPTION
This makes too changes:
* Changes question about ICEs to be about any bug in the compiler
* Adds a place to rate compilation error messages. cc @estebank