### PR TITLE
Ask explicitly about currently using Rust

### DIFF
--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -22,8 +22,8 @@ We estimate it will take about 10-15 minutes to complete.
 
 Select one:
 
-- Yes, I have used Rust [`NEXT`](#your-rust-experience)
-- No, I don't use Rust, but I have in the past [`NEXT`](#for-previous-rust-users)
+- Yes, I use Rust [`NEXT`](#your-rust-experience)
+- No, I don't currently use Rust, but I have in the past [`NEXT`](#for-previous-rust-users)
 - No, I have never used Rust [`NEXT`](#for-non-rust-users)
 
 > **justification**


### PR DESCRIPTION
We explicitly want to differentiate have used Rust in the past vs are currently using Rust.