### PR TITLE
Don't group all UNIXes together

### DIFF
--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -176,6 +176,16 @@ Select all that apply:
 - Mac OS
 - Other (open response)
 
+> **justification**
+>
+> We're using "Linux" here rather than grouping all UNIXes together, to allow
+> us to gauge interest in specific other UNIXes via the fill-in-the-blank
+> "other" option. If we grouped UNIXes together, users of other UNIX systems
+> wouldn't be visible; let's try to capture the level of interest in those
+> systems. As with many questions with an open "other" response; if any
+> specific answer appears frequently, we can add it to future surveys to reduce
+> the amount of work needed to process responses.
+
 ### On the primary machine you compile Rust code on, how many logical CPU threads do you have?
 
 Please count logical CPUs here, not cores or sockets. You can get this number by running the following commands from the command line:
@@ -208,6 +218,11 @@ Select all that apply:
 - Embedded platforms (with an operating system)
 - Embedded platforms (bare metal)
 - Other (open response)
+
+> **justification**
+>
+> We're using "Linux" here rather than "*nix" or similar, with the same
+> justification as in the "Which operating systems do you use" question.
 
 ### Which version(s) of Rust do you use for local development?
 

--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -170,7 +170,7 @@ Rating:
 
 Select all that apply:
 
-- *nix
+- Linux
 - Windows
 - Windows Subsystem for Linux
 - Mac OS
@@ -200,7 +200,7 @@ Free form (optional).
 
 Select all that apply:
 
-- *nix (desktop or server)
+- Linux (desktop or server)
 - Windows
 - Mac OS
 - iOS


### PR DESCRIPTION
This will allow us to gauge interest in specific other UNIXes via the fill-in-the-blank "other" option. Right now, users of other UNIX systems aren't visible; let's try to capture the level of interest in those systems.