### PR TITLE
Add Rust 1.48 as a landmark version in question about which Rust version people use

### DIFF
--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -216,8 +216,8 @@ Type: select all that apply
 
 - Current stable version
 - Previous stable version
-- A specific version of stable Rust equal to or newer than 1.48
-- A specific version of stable Rust older than 1.48
+- A specific version of stable Rust equal to or newer than 1.47
+- A specific version of stable Rust older than 1.47
 - Beta release
 - Latest nightly
 - A specific version of nightly
@@ -229,10 +229,9 @@ Type: select all that apply
 >
 > Together with the following question, we can better determine what the spread of 
 > version usage is across the community.
-> We ask specifically about version 1.48 since it is, at the time of the survey, the 
+> We ask specifically about version 1.47 since it is, at the time of the survey, the 
 > version that was released ~1 year prior. Additionally, at the time of this writing
-> all major Linux distros have a version equal to or newer than this version (with the
-> exception of Alpine which uses 1.47).
+> all major Linux distros have a version equal to or newer than this version.
 
 ### Which version(s) of Rust do you use in automated testing (e.g., CI)?
 


### PR DESCRIPTION
Fixes #135 

