### PR TITLE
Add a question about compiler ram usage

### DIFF
--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -783,6 +783,7 @@ Aspects:
 
 - Compile times
 - Binary size
+- Memory usage (i.e., how much RAM rustc uses when compiling)
 - Disk space usage (e.g., the size of `target` folder)
 - Bugs in the compiler (i.e., ICEs a.k.a. internal compiler errors, miscompilations, etc.)
 - Compiler error messages


### PR DESCRIPTION
I hope the clarification makes it clear that we are not asking about the amount of RAM that Rust programs use just the compiler. 

Fixes #39 