### PR TITLE
Add community survey FAQ

### DIFF
--- a/documents/Community-Survey-FAQ.md
+++ b/documents/Community-Survey-FAQ.md
@@ -1,10 +1,10 @@
 # Rust Language Community Survey FAQ
 
-In this FAQ we try to answer common questions about the Annual Rust Language Community Survey. If in your opinion there is a missing question or if you have a concern about this document, please open an [issue](https://github.com/rust-lang/surveys/issues/new).
+In this FAQ we try to answer common questions about the Annual Rust Language Community Survey. If in your opinion there is a missing question or if you have a concern about this document, please open an [issue](https://github.com/rust-lang/surveys/issues/new) or contact the [Rust Community Team](mailto:community-team@rust-lang.org) directly.
 
 ## Why is this survey important for the Rust project?
 
-[Rust](https://rust-lang.org) is an Open Source project. As such, we want to hear both from people inside and outside of our ecosystem about the language, how it is perceived, and how we can make the language more accessible and our community more welcoming. This feedback will give our community the opportunity to participate in shaping the future of the project. We want to focus on the requirements of the language current and potential users to offer a compelling tool for them to solve real world problems in a safe, efficient, and modern way.
+[Rust](https://rust-lang.org) is an Open Source project. As such, we want to hear both from people inside and outside of our ecosystem about the language, how it is perceived, and how we can make the language more accessible and our community more welcoming. This survey gives our community another opportunity to participate in shaping the future of the project. 
 
 ## What are the goals of the survey?
 
@@ -14,14 +14,14 @@ In this FAQ we try to answer common questions about the Annual Rust Language Com
 
 ## How much time will it take to answer the survey?
 
-In average, it should take from 10 to 25 minutes.
+On average, it should take from 10 to 25 minutes.
 
 ## What kind of questions are included in the survey?
 
-It includes some questions about 
+It includes some questions about:
 
 - basic demographic information
-- how responders use Rust
+- how respondents use Rust
 - their opinions on their usage of Rust and related tooling 
 - their potential usage of Rust at work
 - their experience with Rust in educational settings
@@ -32,11 +32,13 @@ The answers from the survey will be anonymized, aggregated, and summarized. A hi
 
 ## How is personally identifiable information handled?
 
-Nearly every question in the survey is optional. You are welcome to share as much or as little information as you are comfortable with. Only anonymized aggregate data is shared with others, and anyone handling raw data is required to sign a non-disclosure agreement (NDA).
+Nearly every question in the survey is optional. You are welcome to share as much or as little information as you are comfortable with. Only anonymized aggregate data is shared with others, and the small survey subteam handling raw data is required to sign a non-disclosure agreement (NDA).
+
+This year’s survey was commissioned by the Rust Foundation and your responses are subject to the Foundation’s [privacy policy](https://foundation.rust-lang.org/policies/privacy-policy).
 
 ## Where and when is the survey results report published?
 
-We expect to publish results from the survey within a month or two of the survey completion. The survey results will be posted to [project's blog](https://blog.rust-lang.org).
+We expect to publish results from the survey within a month or two of the survey completion. The survey results will be posted to the [project's blog](https://blog.rust-lang.org).
 
 ## Where can I see the previous survey reports?
 

--- a/documents/Community-Survey-FAQ.md
+++ b/documents/Community-Survey-FAQ.md
@@ -32,7 +32,7 @@ The answers from the survey will be anonymized, aggregated, and summarized. A hi
 
 ## How is personally identifiable information handled?
 
-Nearly every question in the survey is optional. You are welcome to share as much or as little information as you are comfortable with. Only anonymized aggregate data is shared with others, and the small survey subteam handling raw data is required to sign a non-disclosure agreement (NDA).
+Nearly every question in the survey is optional. You are welcome to share as much or as little information as you are comfortable with. Only the community survey team will have access to the raw data, and only anonymized aggregate data is shared with others.
 
 This year’s survey was commissioned by the Rust Foundation and your responses are subject to the Foundation’s [privacy policy](https://foundation.rust-lang.org/policies/privacy-policy).
 

--- a/documents/Community-Survey-FAQ.md
+++ b/documents/Community-Survey-FAQ.md
@@ -1,0 +1,47 @@
+# Rust Language Community Survey FAQ
+
+In this FAQ we try to answer common questions about the Annual Rust Language Community Survey. If in your opinion there is a missing question or if you have a concern about this document, please open an [issue](https://github.com/rust-lang/surveys/issues/new).
+
+## Why is this survey important for the Rust project?
+
+[Rust](https://rust-lang.org) is an Open Source project. As such, we want to hear both from people inside and outside of our ecosystem about the language, how it is perceived, and how we can make the language more accessible and our community more welcoming. This feedback will give our community the opportunity to participate in shaping the future of the project. We want to focus on the requirements of the language current and potential users to offer a compelling tool for them to solve real world problems in a safe, efficient, and modern way.
+
+## What are the goals of the survey?
+
+- To understand the community's main development priorities and needs
+- To categorize the population of users of the language
+- To understand perceived strengths and weaknesses of Rust and related tooling
+
+## How much time will it take to answer the survey?
+
+In average, it should take from 10 to 25 minutes.
+
+## What kind of questions are included in the survey?
+
+It includes some questions about 
+
+- basic demographic information
+- how responders use Rust
+- their opinions on their usage of Rust and related tooling 
+- their potential usage of Rust at work
+- their experience with Rust in educational settings
+
+## How will we use the data from the survey responses?
+
+The answers from the survey will be anonymized, aggregated, and summarized. A high level writeup will be posted to blog.rust-lang.org.
+
+## How is personally identifiable information handled?
+
+Nearly every question in the survey is optional. You are welcome to share as much or as little information as you are comfortable with. Only anonymized aggregate data is shared with others, and anyone handling raw data is required to sign a non-disclosure agreement (NDA).
+
+## Where and when is the survey results report published?
+
+We expect to publish results from the survey within a month or two of the survey completion. The survey results will be posted to [project's blog](https://blog.rust-lang.org).
+
+## Where can I see the previous survey reports?
+
+- [State of Rust 2020](https://blog.rust-lang.org/2020/12/16/rust-survey-2020.html)
+- [State of Rust 2019](https://blog.rust-lang.org/2020/04/17/Rust-survey-2019.html)
+- [State of Rust 2018](https://blog.rust-lang.org/2018/11/27/Rust-survey-2018.html)
+- [State of Rust 2017](https://blog.rust-lang.org/2017/09/05/Rust-2017-Survey-Results.html)
+- [State of Rust 2016](https://blog.rust-lang.org/2016/06/30/State-of-Rust-Survey-2016.html)

--- a/surveys/2021-annual-survey/questions.md
+++ b/surveys/2021-annual-survey/questions.md
@@ -4,11 +4,9 @@ Whether or not you use Rust Programming Language <https://rust-lang.org> today, 
 
 The Rust Community Team has created this survey to help us gauge how we're doing, what can be improved, and how we can best engage with all of you as we move forward.
 
-This is your chance to have a say in the development priorities for Rust.
+This is your chance to have a say in the development priorities of Rust.
 
-Unless you choose to enter your email, your answers will be anonymous. Any personal data you submit as a part of this survey will be handled in accordance with our policy as described in our Frequently Asked Questions:
-
-https://github.com/rust-community/team/wiki/State-of-the-Rust-Language-Community-Survey-FAQ
+Your answers will be anonymous. Any personal data you submit as a part of this survey will be handled in accordance with our policy as described in our [Frequently Asked Questions](https://github.com/rust-lang/surveys/blob/main/documents/Community-Survey-FAQ.md).
 
 We estimate it will take about 10-25 minutes to complete.
 


### PR DESCRIPTION
This moves the community survey from its current home [here](https://github.com/rust-community/team/wiki/State-of-the-Rust-Language-Community-Survey-FAQ) to this repo. I also changed some of the content to better reflect the current state of things. 

@Mark-Simulacrum you might want to take a look at this to ensure that things are good enough from a privacy perspective. 

cc @badboy as a representative from the community team