### PR TITLE
Add a faq for contributor survey

### DIFF
--- a/surveys/2021-contributor-survey/FAQ.md
+++ b/surveys/2021-contributor-survey/FAQ.md
@@ -1,0 +1,85 @@
+# Rust Language Contributor Survey FAQ
+
+In this FAQ we try to answer common questions about the Rust Project
+Contributor Survey. If in your opinion there is a missing question or if you
+have a concern about this document, please open an
+[issue](https://github.com/rust-lang/surveys/issues/new) or contact the [Rust
+Community Team](mailto:community-team@rust-lang.org) directly.
+
+## What are the goals of the survey?
+
+This survey seeks to identify areas of support which will most effectively
+benefit the project. Our hope is that the foundation and other organizations
+seeking to support the Rust Project can then use the information gathered via
+this survey to guide their programs over the next year.
+
+## How much time will it take to answer the survey?
+
+On average, it should take from 5 to 15 minutes.
+
+## What kind of questions are included in the survey?
+
+This survey gathers demographic information that can be used to group feedback
+based on areas of involvment and feedback questions that seek to identify
+specific positives and negatives within the rust project contribution
+experience.
+
+## How will we use the data from the survey responses?
+
+The answers from the survey will be anonymized, aggregated, and summarized. A
+high level writeup will be posted to blog.rust-lang.org.
+
+## How is personally identifiable information handled?
+
+Nearly every question in the survey is optional. You are welcome to share as
+much or as little information as you are comfortable with. Only the community
+survey team will have access to the raw data, and only anonymized aggregate
+data is shared with others.
+
+This year’s survey was commissioned by the Rust Foundation and your responses
+are subject to the Foundation’s [privacy
+policy](https://foundation.rust-lang.org/policies/privacy-policy).
+
+## Where and when is the survey results report published?
+
+We expect to publish results from the survey within a month or two of the
+survey completion. The survey results will be posted to the [project's
+blog](https://blog.rust-lang.org).
+
+## How do you define what counts as a contribution and what does it mean to be an active contributor?
+
+A contribution is any sort of interaction that benefits the Rust Project. For
+example, Documentation, Code Review (PRs), Design Review (RFCs/MCPs/FCPs),
+Issue Triage, Issue Reporting, Moderation, New Features, Bug Fixes, Performance
+enhancements, Communication (e.g. writing blog posts, release notes, preparing
+for meetings or taking minutes), supporting/mentoring/guiding other
+contributors, Rollups/CI/Releases, and Governance all count as contribution,
+and this list is not by any means exhaustive. Anything that assists technical
+discussions, identifies issues, or otherwise benefits the project or the
+contributors to the project likely counts as a contribution.
+
+"Active contributor" is a flexible classification that is intended to identify
+individuals who have contributed to the project and plan to continue to
+contribute to the project, regardless of how long the gap between said
+contributions is. If you're not sure if you're an active contributor then
+you're probably an active contributor, but ultimately it comes down to if you
+feel comfortable identifying yourself as such.
+
+The primary difference is that the follow up questions asked of active
+contributors assume a greater familiarity with the contribution process than
+those asked of potential contributors and non-contributors.
+
+## What is the difference between a team, working group, and a project group? How can I tell how my team/group is classified?
+
+Team, working group, and project group are classifications that the project
+uses to loosely classify the various groups that make up the rust project.
+These groups are identified in the [team
+repo](https://github.com/rust-lang/team), and can be disambiguated by the
+`kind` field in their toml entry in the `team/teams` folder.
+
+- team have no `kind` field (e.g. compiler team)
+- working groups have `kind = "working-group"` (e.g. working group polonius)
+- project groups have `kind = "project-group"` (e.g. project group error handling)
+
+If you're unsure of how the groups you're involved in are classified, check
+their entry in the team repo.

--- a/surveys/2021-contributor-survey/questions.md
+++ b/surveys/2021-contributor-survey/questions.md
@@ -57,8 +57,9 @@ Select all that apply:
 ### How long have you been contributing to the Rust Project?
 
 - Less than 3 months
-- 3 to 6 months
-- 1 year
+- 3-6 months
+- 6-12 months
+- 1-2 year
 - 2-3 years
 - 3-5 years
 - 5+ years
@@ -76,10 +77,8 @@ Select all that apply:
 - I am a lead of one or more Rust Teams.
 - I am a member of one or more Rust working groups or project groups.
 - I am a lead of one or more Rust working groups or project groups.
-- I am not a member of a Rust Team, working group, or project group, but I
-  would like to be.
-- I am not a member of a Rust team, working group, or project group, and I have
-  no intention to join one.
+- I am not a member of a Rust Team, working group, or project group, but I would like to be.
+- I am not a member of a Rust team, working group, or project group, and I have no intention to join one.
 
 > **justification**
 >
@@ -341,8 +340,9 @@ Free Form
 ### How long were you a contributor to the Rust Project?
 
 - Less than 3 months
-- 3 to 6 months
-- 1 year
+- 3-6 months
+- 6-12 months
+- 1-2 year
 - 2-3 years
 - 3-5 years
 - 5+ years
@@ -360,10 +360,8 @@ Select all that apply:
 - I was a lead of one or more Rust Teams.
 - I was a member of one or more Rust working groups or project groups.
 - I was a lead of one or more Rust working groups or project groups.
-- I was not a member of a Rust Team, working group, or project group, but I
-  wanted to be.
-- I was not a member of a Rust team, working group, or project group, and I had
-  no intention of joining one.
+- I was not a member of a Rust Team, working group, or project group, but I wanted to be.
+- I was not a member of a Rust team, working group, or project group, and I had no intention of joining one.
 
 > **justification**
 >


### PR DESCRIPTION
also includes some minor changes from when I was entering the survey into surveyhero as a separate commit.

Note, I feel like I got a little too informal when filling out the FAQ entries for the last two questions, so I'd appreciate review and feedback on those sections in particular.