### PR TITLE
Add Hong Kong SAR to the list of places to live

### DIFF
--- a/surveys/2022-annual-survey/questions.md
+++ b/surveys/2022-annual-survey/questions.md
@@ -702,6 +702,7 @@ Type: select one (optional)
 - *all UN member states*
 - *two observer states (Vatican City and Palestine)*
 - Taiwan
+- Hong Kong SAR
 - Other
 
 > **justification**


### PR DESCRIPTION
The place where is live is not listed as an option.  From Wikipedia (https://en.wikipedia.org/wiki/Hong_Kong):

Hong Kong, officially the Hong Kong Special Administrative Region of the People's Republic of China (abbr. Hong Kong SAR)