### PR TITLE
Add link to 2022 survey to the FAQ

### DIFF
--- a/documents/Community-Survey-FAQ.md
+++ b/documents/Community-Survey-FAQ.md
@@ -42,6 +42,7 @@ We expect to publish results from the survey within a month or two of the survey
 
 ## Where can I see the previous survey reports?
 
+- [State of Rust 2022](https://blog.rust-lang.org/2023/08/07/Rust-Survey-2023-Results.html)
 - [State of Rust 2021](https://blog.rust-lang.org/2022/02/15/Rust-Survey-2021.html)
 - [State of Rust 2020](https://blog.rust-lang.org/2020/12/16/rust-survey-2020.html)
 - [State of Rust 2019](https://blog.rust-lang.org/2020/04/17/Rust-survey-2019.html)


### PR DESCRIPTION
Btw, the URL of the last results (2022 survey) on the blog should probably contain `2022` and not `2023` (but I guess that to avoid churn and broken links, it shouldn't be changed now).