### PR TITLE
Add analysis automation scripts

### DIFF
--- a/report/README.md
+++ b/report/README.md
@@ -1,0 +1,29 @@
+# Survey report scripts
+This directory contains scripts that automate the generation of charts, reports and Rust Blog posts that analyse
+surveys created in SurveyHero.
+
+Note that these scripts are intended to be used as a library, so you will need to write your own script to leverage them.
+It is best to take a look at their usage from previous surveys, and start with that.
+
+To use the scripts, you should install their dependencies first:
+```bash
+$ python3 -m venv venv
+$ source venv/venv/bin/activate
+(venv) $ pip install -U setuptools wheel pip  
+(venv) $ pip install -r requirements.txt
+```
+
+and then add this directory to the `PYTHONPATH` of your main Python script, and then use e.g. `from surveyhero.parser import parse_surveyhero_report`.
+
+## Useful functions
+First, you will probably want to export data from SurveyHero into two CSV files - one containing the aggregated data from
+the report, and a second one that contains the individual answers from all the respondents.
+
+Then you should use `parser.py:parse_surveyhero_report` to parse the report CSV, and `parser.py:parse_surveyhero_answers`
+to parse the full answer CSV (if needed). Once you do that, you can start to build a `ChartReport` (located in `report.py`),
+by adding various charts to it with the provided helper methods. The charts are created out of `Question`s that you can
+access from the parsed CSVs.
+
+Once you create fill a `ChartReport` with charts, you can use it to render a PDF report using the `render.py:render_report_to_pdf`
+function, or to render a Rust Blog post template using the `render.py:render_blog_post` function. See the documentation
+of these two functions for more details.

--- a/report/requirements.txt
+++ b/report/requirements.txt
@@ -1,0 +1,11 @@
+plotly==5.18.0
+kaleido==0.2.1
+pandas==2.1.4
+matplotlib==3.8.2
+wordcloud==1.9.3
+elsie[cairo]==3.4
+beautifulsoup4==4.12.3
+lxml==4.6.5
+tqdm==4.66.1
+multiprocess==0.70.16
+dill==0.3.8

--- a/report/surveyhero/chart.py
+++ b/report/surveyhero/chart.py
@@ -1,0 +1,346 @@
+import textwrap
+from collections import defaultdict
+from typing import List, Any, Dict, Optional
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+from plotly.graph_objs import Figure
+from wordcloud import WordCloud
+
+from .survey import Question, MatrixQuestion
+
+
+def format_title(question: Question, include_kind: bool = False) -> str:
+    kind = ""
+    if include_kind:
+        kind = "single answer" if question.is_single_answer() else "multiple answers"
+        kind = f", {kind}"
+
+    return f'<b>{wrap_text(question.question, max_width=75)}</b><br /><span style="font-size: 0.8em;">(total responses = {question.total_responses}{kind})</span>'
+
+
+def scale_font(ref_value: int, ref_height: int, height: int, max=22) -> int:
+    ratio = height / ref_height
+    return min(max, int(ratio * ref_value))
+
+
+def wrap_text(text: str, max_width: int) -> str:
+    text = textwrap.wrap(text, width=max_width, break_long_words=False)
+    text = "<br />".join(text)
+    return text
+
+
+def make_bar_chart(
+        questions: List[Question],
+        height=600,
+        bar_label_vertical=False,
+        xaxis_tickangle=0,
+        max_tick_width=30,
+        legend_order: Optional[List[str]] = None,
+        layout_args: Optional[Dict[str, Any]] = None
+) -> Figure:
+    assert len(questions) > 0
+    assert len(set(question.year for question in questions)) == len(questions)
+
+    if legend_order is not None:
+        legend_order = [wrap_text(l, max_width=max_tick_width) for l in legend_order]
+
+    data = defaultdict(list)
+    totals = {}
+
+    for question in questions:
+        assert question.is_simple()
+        for answer in question.kind.answers:
+            text = wrap_text(answer.answer, max_width=max_tick_width)
+
+            data["year"].append(str(question.year))
+            data["answer"].append(text)
+            data["count"].append(answer.count)
+        totals[str(question.year)] = question.total_responses
+    data = pd.DataFrame(data)
+    multiyear = len(data["year"].unique()) > 1
+
+    answers = list(data["answer"].unique())
+
+    # To have a nicer legend
+    data = data.rename(columns={"year": "Year"})
+    data["percent"] = 0.0
+
+    # Backfill missing answers
+    for answer in answers:
+        for year in totals.keys():
+            count = data[(data["answer"] == answer) & (data["Year"] == year)]
+            if len(count) == 0:
+                data = pd.concat((data, pd.DataFrame({
+                    "answer": [answer],
+                    "Year": [year],
+                    "count": [0]
+                })))
+
+    # Calculate percent from all responses of that given year
+    for (year, total_count) in totals.items():
+        counts = data.loc[data["Year"] == year, "count"].astype(np.float32)
+        data.loc[data["Year"] == year, "percent"] = (counts / total_count) * 100.0
+
+    main_year = str(questions[0].year)
+
+    def sort_key(answer: str) -> int:
+        if legend_order is not None:
+            return legend_order[::-1].index(answer)
+
+        key = (data["answer"] == answer) & (data["Year"] == main_year)
+        return int(data.loc[key, "count"].sum())
+
+    answers = sorted(answers, key=sort_key, reverse=True)
+
+    # Generate label that is shown above each bar
+    data["text"] = data.apply(lambda r: f"{r['percent']:.1f}%", axis=1)
+
+    reference_height = 800
+
+    fig = px.bar(
+        data,
+        x="answer",
+        y="percent",
+        color="Year",
+        barmode="group",
+        text="text",
+        custom_data=["Year", "count"],
+        category_orders={"answer": answers},
+        height=height,
+    )
+    fig.update_traces(
+        textposition="outside",
+        hovertemplate="Year: %{customdata[0]}<br />Count: %{customdata[1]}<br />Percent: %{text}<extra></extra>",
+        textangle=-90 if bar_label_vertical else 0,
+    )
+
+    layout_args = layout_args or {}
+    fig.update_layout(
+        meta="bar-chart",
+        hoverlabel=dict(
+            bgcolor="white",
+            font_size=scale_font(24, reference_height, height),
+            font_family="Rockwell"
+        ),
+        hovermode="x unified",
+        xaxis_title=None,
+        # xaxis_tickwidth=40,
+        xaxis_tickangle=xaxis_tickangle,
+        yaxis_title="Percent out of all responses (%)",
+        yaxis_range=[0, 119],
+        yaxis_ticksuffix="%",
+        yaxis_fixedrange=True,
+        title_text=format_title(questions[0], include_kind=True),
+        plot_bgcolor="rgb(255, 255, 255)",
+        showlegend=multiyear,
+        uniformtext=dict(
+            minsize=12,
+            mode="show"
+        ),
+        margin=dict(
+            pad=10,
+            b=10
+        ),
+        dragmode="pan",
+        **layout_args
+    )
+
+    title_standoff = 50
+    if height > 400:
+        title_standoff = 25
+    fig.update_yaxes(
+        nticks=10,
+        rangemode="tozero",
+        gridcolor="rgb(229, 236, 246)",
+        title_standoff=title_standoff
+        # showgrid=False
+    )
+
+    return fig
+
+
+def make_pie_chart(
+        question: Question,
+        height=800,
+        legend_params: Optional[Dict[str, Any]] = None,
+        legend_order: Optional[List[str]] = None,
+        max_label_width=30,
+) -> Figure:
+    assert question.is_simple()
+
+    # For questions with multiple answers, a pie chart would show wrong results
+    assert question.is_single_answer()
+
+    data = defaultdict(list)
+    for answer in question.kind.answers:
+        text = wrap_text(answer.answer, max_width=max_label_width)
+        data["answer"].append(text)
+        data["count"].append(answer.count)
+        data["percent"].append((answer.count / question.total_responses) * 100)
+
+    category_orders = {}
+    if legend_order is not None:
+        category_orders["answer"] = legend_order
+
+    df = pd.DataFrame(data)
+    fig = px.pie(
+        df,
+        values="count",
+        names="answer",
+        title=format_title(question),
+        custom_data=["percent"],
+        height=height,
+        category_orders=category_orders
+    )
+    fig.update_traces(
+        # textposition="outside",
+        # textinfo="percent+label",
+        # outsidetextfont=dict(size=10),
+        textposition="inside",
+        textinfo="percent",
+        hovertemplate="Answer: %{label}<br />Count: %{value} <br />Percent: %{customdata:.2f}%"
+    )
+
+    legend = {}
+    # y=0,
+    # x=0,
+    # xref="container",
+    # yref="container",
+    # yanchor="top",
+    # xanchor="right",
+    if legend_params is not None:
+        legend.update(legend_params)
+
+    fig.update_layout(
+        meta="pie-chart",
+        hoverlabel=dict(
+            bgcolor="white",
+            font_size=16,
+            font_family="Rockwell",
+        ),
+        # showlegend=False,
+        showlegend=True,
+        legend=legend,
+        margin=dict(
+            l=0,
+            b=0,
+            pad=0
+        ),
+        dragmode="pan"
+    )
+
+    return fig
+
+
+def make_matrix_chart(
+        question: Question,
+        categories: List[str],
+        category_label: str,
+        height=600,
+        horizontal: bool = False,
+        max_label_width=20,
+        legend_params: Optional[Dict[str, Any]] = None
+) -> Figure:
+    """
+    Create a matrix chart with different categories.
+    `categories`: List of categories, sorted from most to least important
+    """
+    assert isinstance(question.kind, MatrixQuestion)
+
+    mapping = dict(zip(categories[::-1], range(1, len(categories) + 1)))
+
+    items = question.kind.answer_groups.items()
+    items = [(wrap_text(group, max_width=max_label_width), value) for (group, value) in items]
+
+    group_score = {}
+    data = defaultdict(list)
+    for (group, levels) in items:
+        score = 0
+        total_count = sum(answer.count for answer in levels)
+        for answer in levels:
+            data["Category"].append(group)
+            data[category_label].append(answer.answer)
+
+            percent = (answer.count / total_count) * 100
+            data["Count"].append(percent)
+            data["Percent (out of this category)"].append(f"{percent:.2f}%")
+            score += answer.count * mapping[answer.answer]
+        score /= total_count
+        group_score[group] = score
+
+    group_keys = sorted(group_score.keys(), key=lambda k: group_score[k], reverse=True)
+    df = pd.DataFrame(data)
+
+    keys = dict(x="Count", y="Category")
+    if not horizontal:
+        keys = dict(y="Count", x="Category")
+
+    fig = px.bar(
+        df,
+        **keys,
+        color=category_label,
+        text="Percent (out of this category)",
+        category_orders=dict(
+            Category=group_keys
+        ),
+        title=format_title(question),
+        height=1000 if not horizontal else height,
+        hover_data=[category_label]
+    )
+    fig.update_traces(
+        orientation="h" if horizontal else "v",
+        textposition="outside",
+        hovertemplate=f"Category: %{{y}}<br />{category_label}: %{{customdata[0]}}<br />Percent: %{{text}}<extra></extra>",
+    )
+
+    legend = {}
+    if legend_params is not None:
+        legend.update(legend_params)
+
+    layout_args = {}
+    if horizontal:
+        layout_args["xaxis_range"] = [0, 110]
+
+    fig.update_layout(
+        meta="matrix-chart",
+        hoverlabel=dict(
+            bgcolor="white",
+            font_size=16,
+            font_family="Rockwell",
+        ),
+        # hovermode="y unified",
+        yaxis_title=None,
+        yaxis_tickangle=0,
+        # https://stackoverflow.com/a/52397461/1107768
+        yaxis_ticksuffix="   ",
+        yaxis_fixedrange=True,
+        xaxis_title="Percent out of the category (%)",
+        xaxis_ticksuffix="%",
+        xaxis_fixedrange=True,
+        legend=legend,
+        dragmode="pan",
+        **layout_args
+    )
+    fig.update_xaxes(
+        showgrid=False,
+    )
+
+    return fig
+
+
+def make_wordcloud(answers: List[str], height=600) -> bytes:
+    from matplotlib import colormaps
+    from .render import pillow_to_png_bytes
+
+    wc = WordCloud(
+        width=800,
+        height=height,
+        scale=1,
+        min_word_length=3,
+        colormap=colormaps["summer"],
+        max_words=50,
+        random_state=42
+    ).generate(" ".join(answers))
+    return pillow_to_png_bytes(wc.to_image())

--- a/report/surveyhero/parser.py
+++ b/report/surveyhero/parser.py
@@ -1,0 +1,107 @@
+import csv
+import re
+from collections import defaultdict
+from pathlib import Path
+
+from .survey import SurveyFullAnswers, Question, MatrixQuestion, Answer, SimpleQuestion, SurveyReport
+
+
+def parse_surveyhero_answers(path: Path, year: int) -> SurveyFullAnswers:
+    """
+    Parses the full CSV from SurveyHero,
+    which contains all responses from individual respondents (except
+    for sensitive data, which should have been filtered after export
+    from SH).
+    """
+    answers = defaultdict(list)
+    with open(path) as f:
+        reader = csv.reader(f)
+        questions = next(reader)
+        total_respondents = 0
+
+        for line in reader:
+            total_respondents += 1
+            for (id, answer) in enumerate(line):
+                answer = answer.strip()
+                if answer:
+                    answers[id].append(answer)
+    return SurveyFullAnswers(
+        year=year,
+        answers=answers,
+        questions=questions,
+        total_respondents=total_respondents
+    )
+
+
+COUNT_REGEX = re.compile(r" \(n = (\d+)\)$")
+
+
+def parse_surveyhero_report(path: Path, year: int) -> SurveyReport:
+    """
+    Parses the report CSV from SurveyHero,
+    which contains aggregated response counts for individual answers.
+    """
+    with open(path) as f:
+        active_question = None
+        questions = []
+
+        for row in csv.reader(f):
+            if row and "Answer" in row:
+                if active_question is not None:
+                    questions.append(active_question)
+                question = row[0]
+                kind = SimpleQuestion(answers=[])
+                if row[1] == "Row":
+                    kind = MatrixQuestion(answer_groups=defaultdict(list))
+
+                count = int(COUNT_REGEX.search(question).group(1))
+                question = question[:question.rindex("(")].strip()
+                active_question = Question(
+                    id=len(questions),
+                    year=year,
+                    question=normalize_question(question),
+                    total_responses=count,
+                    kind=kind
+                )
+            else:
+                assert active_question is not None
+
+                if all(r == "" for r in row):
+                    # Empty row
+                    continue
+                elif "Average" in row or "Standard Deviation" in row:
+                    # Statistics
+                    continue
+                else:
+                    if isinstance(active_question.kind, SimpleQuestion):
+                        answer = row[1]
+                        count = int(row[2])
+                        active_question.kind.answers.append(Answer(
+                            answer=normalize_answer(answer),
+                            count=count,
+                        ))
+                    elif isinstance(active_question.kind, MatrixQuestion):
+                        group = normalize_answer(row[1])
+                        answer = row[2]
+                        count = int(row[3])
+                        active_question.kind.answer_groups[group].append(Answer(
+                            answer=normalize_answer(answer),
+                            count=count,
+                        ))
+                    else:
+                        print(row)
+                        assert False
+        if active_question is not None:
+            questions.append(active_question)
+    return SurveyReport(
+        questions=questions,
+        year=year
+    )
+
+
+def normalize_question(question: str) -> str:
+    return question.lstrip("- ").strip()
+
+
+def normalize_answer(answer: str) -> str:
+    return answer.rstrip(".").strip()

--- a/report/surveyhero/render.py
+++ b/report/surveyhero/render.py
@@ -1,0 +1,261 @@
+import dataclasses
+import io
+import os
+import re
+import tempfile
+from pathlib import Path
+from typing import Union, Tuple, Any
+
+import tqdm
+from PIL import Image
+from bs4 import BeautifulSoup
+
+from .report import ChartReport, PlotlyRenderer, PngRenderer, ChartRenderer
+
+CHART_MARKER_REGEX = re.compile(r"<!-- chart: ([^ ]*)\s*(\([^)]*\))?\s*-->")
+
+
+@dataclasses.dataclass(frozen=True)
+class RenderedChart:
+    script: str
+    tag: str
+    to_replace: str
+
+
+def make_rel_path(image_root: Path, path: Path) -> str:
+    path = path.relative_to(image_root)
+    return f"../../../images/{path}"
+
+
+def render_png(image_dir: Path, renderer: ChartRenderer, chart_id: str) -> Path:
+    png_bytes = renderer.to_image_bytes(format="png")
+    png_bytes = optimize_png_image(png_bytes)
+    png_path = image_dir / f"{chart_id}.png"
+    with open(png_path, "wb") as f:
+        f.write(png_bytes)
+    return png_path
+
+
+def render_blog_chart(arg) -> RenderedChart:
+    (image_root, image_dir, report, match) = arg
+
+    fullmatch = match[0]
+    chart_id = match[1]
+    if chart_id not in report.charts:
+        raise Exception(f"Chart with ID `{chart_id}` was not found")
+    chart = report.get_chart(chart_id)
+
+    def normalize_arg(key, value) -> Tuple[str, Any]:
+        value = int(value)
+        if key == "xrange":
+            key = "layout_args"
+            value = dict(xaxis_range=(-1, value))
+        return (key, value)
+
+    # Skip ()
+    args = match[2] or ""
+    args = args[1:-1]
+    args = args.split(",")
+    args = dict(normalize_arg(*tuple(arg.split("="))) for arg in args if arg.strip())
+
+    height = args.get("height", 600)
+
+    # Render the chart as PNG and SVG
+    png_path = render_png(image_dir=image_dir, renderer=chart, chart_id=chart_id)
+
+    svg_bytes = chart.to_image_bytes(format="svg")
+    svg_path = image_dir / f"{chart_id}.svg"
+    with open(svg_path, "wb") as f:
+        f.write(svg_bytes)
+
+    if isinstance(chart, PlotlyRenderer):
+        figure = chart.render_fn(**args)
+        chart_type = figure.layout.meta
+        element = BeautifulSoup(figure.to_html(full_html=False, include_plotlyjs=None, div_id=chart_id),
+                                features="html.parser").div
+        div = element.find("div")
+        div["class"] = chart_type
+        div.append(BeautifulSoup(f"""<noscript>
+    <img src="{make_rel_path(image_root=image_root, path=png_path)}" height="{height}" alt="{chart_id}" />
+</noscript>""", "html.parser"))
+
+        links = [
+            (make_rel_path(image_root=image_root, path=png_path), "Download chart as PNG", "PNG"),
+            (make_rel_path(image_root=image_root, path=svg_path), "Download chart as SVG", "SVG"),
+        ]
+
+        wordcloud_id = f"{chart_id}-wordcloud"
+        wordcloud = report.get_chart(wordcloud_id)
+        if wordcloud is not None:
+            wc_png_path = render_png(image_dir=image_dir, renderer=wordcloud, chart_id=wordcloud_id)
+            links.append(
+                (make_rel_path(image_root=image_root, path=wc_png_path), "Download open answers as wordcloud PNG",
+                 "Wordcloud of open answers")
+            )
+
+        links = [f"""<span>[<a href="{link}" target="_href_" title="{title}">{label}</a>]</span>"""
+                 for (link, title, label) in links]
+        tag = f"""<!-- Chart {chart_id} start -->
+<div>
+    {div}
+    <div style="display: flex; margin-bottom: 10px;">
+        {'&nbsp;'.join(links)}
+    </div>
+</div>
+<!-- Chart {chart_id} end -->"""
+
+        script = element.find("script")
+        assert script is not None
+        return RenderedChart(
+            script=str(script),
+            tag=tag,
+            to_replace=fullmatch
+        )
+    elif isinstance(chart, PngRenderer):
+        assert False
+    else:
+        assert False
+
+
+def render_blog_post(
+        template: Path,
+        blog_root: Path,
+        image_dir: str,
+        report: ChartReport
+):
+    """
+    Render a Rust Blog post containing special placeholders that will render as SurveyHero charts from the given `report`.
+
+    The `template` should contain two things:
+    1) A line containing `<!-- chart: <chart-id> -->` for each charts that should be rendered.
+    The chart placeholder can contain optional key-value arguments that will be passed to the chart render function:
+    ```
+    <!-- chart: my-chart-1 (height=400) -->
+    ```
+    2) A line containing `<!-- scripts -->`, which will be replaced with all the generated JavaScript. It should be ideally
+    at the end of the template.
+
+    :param template: Blog post Markdown template. Its filename will be used to name the generated blog post file.
+    :param blog_root: Local checkout of the https://github.com/rust-lang/blog.rust-lang.org repository
+    :param image_dir: Name of a directory in <blog_root/static/images> where the rendered charts will be stored.
+    :param report: `ChartReport` containing charts that can be rendered.
+    """
+    output_path = blog_root / "posts" / template.name
+
+    image_root = blog_root / "static" / "images"
+    image_dir = image_root / image_dir
+    image_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Generating blog post to {output_path}, image directory {image_dir}")
+
+    with open(template) as f:
+        document = f.read()
+
+    scripts = ['<script charset="utf-8" src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>']
+    matches = list(CHART_MARKER_REGEX.finditer(document))
+
+    args = [
+        (image_root, image_dir, report, (match.group(0), match.group(1), match.group(2)))
+        for match in matches
+    ]
+
+    import multiprocess as mp
+
+    with mp.Pool() as pool:
+        for result in tqdm.tqdm(pool.imap(render_blog_chart, args), total=len(args)):
+            scripts.append(result.script)
+            document = document.replace(result.to_replace, result.tag)
+
+    # Helper JavaScript script that makes charts better visible on mobile phones
+    scripts.append("""<script type="text/javascript">
+// Angle axis ticks and make bar chart labels vertical on small displays
+function relayoutCharts() {
+    if (window.innerWidth > 800) return;
+
+    console.log("Relayouting charts");
+    var bar_charts = document.getElementsByClassName("bar-chart");
+    for (var i = 0; i < bar_charts.length; i++) {
+        var chart = bar_charts[i];
+        Plotly.relayout(chart, {xaxis: {tickangle: 45}});
+        Plotly.restyle(chart, {textangle: -90});
+    }
+}
+
+window.addEventListener("resize", relayoutCharts);
+document.addEventListener("DOMContentLoaded", relayoutCharts);
+</script>""")
+
+    script_marker = "<!-- scripts -->"
+    if script_marker not in document:
+        raise Exception(f"Please add `{script_marker}` to the (end of the) Markdown document")
+    script_str = "<!-- Chart scripts -->\n\n" + "\n\n".join(scripts)
+    document = document.replace(script_marker, script_str)
+
+    with open(output_path, "w") as f:
+        f.write(document)
+
+
+def render_pdf_page(args) -> Tuple[str, str, Union[str, bytes]]:
+    report, name = args
+    chart = report.get_chart(name)
+    svg_bytes = chart.to_image_bytes(format="svg")
+    if svg_bytes is not None:
+        with tempfile.NamedTemporaryFile(suffix=".svg", delete=False) as f:
+            f.write(svg_bytes)
+            path = f.name
+        return (name, "svg", path)
+    else:
+        png_bytes = chart.to_image_bytes(format="png")
+        png_bytes = optimize_png_image(png_bytes)
+        return (name, "png", png_bytes)
+
+
+def render_report_to_pdf(report: ChartReport, output: Path, title: str, include_labels=False):
+    """
+    Renders a PDF report containing all charts from the given `report` into the `output` path.
+    """
+    import elsie
+    from elsie.render.backends.cairo.backend import CairoBackend
+
+    # A4 format
+    slides = elsie.SlideDeck(backend=CairoBackend(), width=595, height=842)
+    slide = slides.new_slide()
+    slide.box().text(title)
+
+    print("Rendering charts")
+
+    import multiprocess as mp
+
+    args = [(report, name) for name in report.charts.keys()]
+    with mp.Pool() as pool:
+        for (name, format, result) in tqdm.tqdm(pool.imap(render_pdf_page, args), total=len(args)):
+            slide = slides.new_slide()
+
+            if name.endswith("-wordcloud"):
+                slide.box(y=150).text("Wordcloud of open answers for the previous chart:",
+                                      style=elsie.TextStyle(size=20))
+
+            box = slide.box(width="95%")
+            if format == "png":
+                box.image(result, image_type="png")
+            elif format == "svg":
+                box.image(result)
+                os.unlink(result)
+            else:
+                assert False
+            if include_labels:
+                slide.box(x=5, y=5).text(name, style=elsie.TextStyle(size=10))
+    print("Rendering PDF")
+    slides.render(str(output))
+
+
+def optimize_png_image(image: bytes) -> bytes:
+    img = Image.open(io.BytesIO(image))
+    img = img.convert("P", palette=Image.ADAPTIVE, colors=256)
+    return pillow_to_png_bytes(img)
+
+
+def pillow_to_png_bytes(image: Image.Image) -> bytes:
+    with io.BytesIO() as buffer:
+        image.save(buffer, format="png", optimize=True)
+        buffer.seek(0)
+        return buffer.getvalue()

--- a/report/surveyhero/report.py
+++ b/report/surveyhero/report.py
@@ -1,0 +1,91 @@
+from typing import Dict, Optional, List
+
+from .chart import make_bar_chart, make_pie_chart, make_wordcloud, make_matrix_chart
+from .survey import Question, normalize_open_answers, MatrixQuestion
+
+
+class ChartRenderer:
+    def __init__(self, name: str, render_fn):
+        self.name = name
+        self.render_fn = render_fn
+
+    def to_image_bytes(self, format: str, **kwargs) -> Optional[bytes]:
+        raise NotImplementedError
+
+
+class PlotlyRenderer(ChartRenderer):
+    def __init__(self, name: str, render_fn):
+        super().__init__(name, render_fn)
+
+    def to_image_bytes(self, format: str, **kwargs) -> Optional[bytes]:
+        render_args = dict()
+        if format == "png":
+            render_args["scale"] = 2
+        return self.render_fn(**kwargs).to_image(format=format, **render_args)
+
+
+class PngRenderer(ChartRenderer):
+    def __init__(self, name: str, render_fn):
+        super().__init__(name, render_fn)
+
+    def to_image_bytes(self, format="png", **kwargs) -> Optional[bytes]:
+        if format != "png":
+            return None
+        return self.render_fn(**kwargs)
+
+
+def join(a, b):
+    a = dict(a)
+    a.update(b)
+    return a
+
+
+class ChartReport:
+    """
+    Container that aggregates charts under IDs (string names).
+    It can be used to render these charts to a PDF report or a blog post (see `render.py`).
+    """
+    def __init__(self):
+        self.charts: Dict[str, ChartRenderer] = {}
+
+    def add_bar_chart(self, name: str, question: Question, baseline: Optional[Question] = None, **kwargs):
+        questions = [question]
+        if baseline is not None:
+            questions.append(baseline)
+
+        def render_fn(**args):
+            return make_bar_chart(questions=questions, **join(kwargs, args))
+
+        self.add_renderer(name, PlotlyRenderer(name=name, render_fn=render_fn))
+
+    def add_pie_chart(self, name: str, question: Question, **kwargs):
+        assert question.is_simple()
+        assert question.is_single_answer()
+
+        def render_fn(**args):
+            return make_pie_chart(question=question, **join(kwargs, args))
+
+        self.add_renderer(name, PlotlyRenderer(name=name, render_fn=render_fn))
+
+    def add_matrix_chart(self, name: str, question: Question, **kwargs):
+        assert isinstance(question.kind, MatrixQuestion)
+
+        def render_fn(**args):
+            return make_matrix_chart(question=question, **join(kwargs, args))
+
+        self.add_renderer(name, PlotlyRenderer(name=name, render_fn=render_fn))
+
+    def add_wordcloud(self, name: str, answers: List[str], **kwargs):
+        answers = normalize_open_answers(answers)
+
+        def render_fn(**args):
+            return make_wordcloud(answers, **join(kwargs, args))
+
+        self.add_renderer(name, PngRenderer(name=name, render_fn=render_fn))
+
+    def get_chart(self, name: str) -> Optional[ChartRenderer]:
+        return self.charts.get(name)
+
+    def add_renderer(self, name: str, renderer: ChartRenderer):
+        assert name not in self.charts
+        self.charts[name] = renderer

--- a/report/surveyhero/survey.py
+++ b/report/surveyhero/survey.py
@@ -1,0 +1,150 @@
+import dataclasses
+from typing import List, Union, Dict, Optional
+
+import pandas as pd
+
+
+@dataclasses.dataclass
+class Answer:
+    answer: str
+    count: int
+
+
+@dataclasses.dataclass
+class SimpleQuestion:
+    answers: List[Answer]
+
+    def rename_answers(self, diff: Dict[str, Optional[str]]) -> "SimpleQuestion":
+        diff = dict(diff)
+
+        answers = []
+        for answer in self.answers:
+            if answer.answer in diff:
+                updated = diff.pop(answer.answer)
+                if updated is None:
+                    continue
+                answer = dataclasses.replace(answer, answer=updated)
+            answers.append(answer)
+        assert len(diff) == 0
+        return dataclasses.replace(self, answers=answers)
+
+
+@dataclasses.dataclass
+class MatrixQuestion:
+    answer_groups: Dict[str, List[Answer]]
+
+    def rename_answers(self, diff: Dict[str, str]) -> "MatrixQuestion":
+        diff = dict(diff)
+
+        answer_groups = {}
+        for (group, items) in self.answer_groups.items():
+            if group in diff:
+                group = diff.pop(group)
+            answer_groups[group] = items
+        if len(diff) > 0:
+            raise Exception(f"Rename answers diff not empty: {diff}")
+        return dataclasses.replace(self, answer_groups=answer_groups)
+
+
+QuestionKind = Union[SimpleQuestion, MatrixQuestion]
+
+
+@dataclasses.dataclass
+class Question:
+    id: int
+    year: int
+    question: str
+    total_responses: int
+    kind: QuestionKind
+
+    def is_simple(self) -> bool:
+        return isinstance(self.kind, SimpleQuestion)
+
+    def is_single_answer(self) -> bool:
+        if isinstance(self.kind, SimpleQuestion):
+            return sum(answer.count for answer in self.kind.answers) == self.total_responses
+        elif isinstance(self.kind, MatrixQuestion):
+            return False
+        else:
+            assert False
+
+    def combine_answers(self, diff: Dict[str, List[str]]) -> "Question":
+        assert self.is_simple()
+
+        orig_count = sum(a.count for a in self.kind.answers)
+        answers_orig = {a.answer: a for a in self.kind.answers}
+        answers = []
+        for (target, old_answers) in diff.items():
+            count = 0
+            for answer in old_answers:
+                count += answers_orig[answer].count
+                answers_orig.pop(answer)
+            assert count > 0
+            answers.append(Answer(answer=target, count=count))
+        answers.extend(answers_orig.values())
+
+        answer_texts = {a.answer: index for (index, a) in enumerate(self.kind.answers)}
+        answers = sorted(answers, key=lambda a: (
+            answer_texts.get(a.answer, 999),
+            a.answer
+        ))
+        assert orig_count == sum(a.count for a in answers)
+        return dataclasses.replace(self, kind=SimpleQuestion(answers=answers))
+
+    def rename_answers(self, diff: Dict[str, Optional[str]]) -> "Question":
+        return dataclasses.replace(self, kind=self.kind.rename_answers(diff))
+
+    def add_open(self, open_answers: List[str], id: str, label: str, replace="Other") -> "Question":
+        """
+        Adds a open answer with the normalized `id` under `label` to this question.
+        The count added from the open answer will reduce the count present in the `replace` answer.
+        """
+        assert self.is_simple()
+        aggregated = pd.Series(open_answers).value_counts()
+        added_count = 0
+        for key in aggregated.index:
+            if id in key:
+                added_count += int(aggregated[key])
+        assert added_count > 0
+
+        answers = []
+        replaced = False
+        for answer in self.kind.answers:
+            count = answer.count
+            if answer.answer == replace:
+                count -= added_count
+                assert not replaced
+                replaced = True
+            answers.append(dataclasses.replace(answer, count=count))
+        assert replaced
+        answers.append(Answer(answer=label, count=added_count))
+        return dataclasses.replace(self, kind=SimpleQuestion(answers=answers))
+
+
+@dataclasses.dataclass
+class SurveyReport:
+    year: int
+    questions: List[Question]
+
+    def q(self, index: int) -> Question:
+        return self.questions[index]
+
+
+@dataclasses.dataclass
+class SurveyFullAnswers:
+    year: int
+    # Question index -> list of open answers
+    answers: Dict[int, List[str]]
+    questions: List[str]
+    total_respondents: int
+
+
+def normalize_open_answers(answers: List[str], replace_spaces=False) -> List[str]:
+    new_answers = list()
+    for answer in answers:
+        answer = answer.lower().strip()
+        if replace_spaces:
+            answer = answer.replace(" ", "-")
+        answer = answer.replace("rust", "").strip()
+        new_answers.append(answer)
+    return new_answers


### PR DESCRIPTION
This PR adds my Python chart and report automation scripts that were used to generate the 2023 Annual survey [analysis](https://github.com/rust-lang/blog.rust-lang.org/pull/1249). These scripts are general, and can be used in the future to generate reports, charts and a blog post for any SurveyHero survey that we perform, in a matter of minutes or hours (depending on the sizte of the survey).