### PR TITLE
Add Leadership Council annual survey

### DIFF
--- a/surveys/micro/leadership-council-2024.md
+++ b/surveys/micro/leadership-council-2024.md
@@ -1,0 +1,23 @@
+# Survey questions
+
+This is a quick annual survey for Rust-lang project members to provide feedback on the [Leadership Council](https://forge.rust-lang.org/governance/council.html). Your feedback is appreciated to help steer the Council activities. As always, if you have specific questions or feedback that you would like to provide, feel free to reach out to your Council representative.
+
+This survey is anonymous, though the Council will see the answers. A summary of these results will be released after the survey is complete.
+
+## Leadership Council Effectiveness
+
+### Do you feel that the Rust Leadership Council is serving its purpose effectively?
+
+Type: select one (optional)
+
+- Agree
+- Neither agree nor disagree
+- Disagree
+
+### Are there areas of the Leadership Council that you think are going well?
+
+Type: free text (optional)
+
+### Are there areas of the Leadership Council that you think could be improved or efforts that should be prioritized?
+
+Type: free text (optional)

--- a/surveys/micro/leadership-council-2024.md
+++ b/surveys/micro/leadership-council-2024.md
@@ -2,7 +2,7 @@
 
 This is a quick annual survey for Rust-lang project members to provide feedback on the [Leadership Council](https://forge.rust-lang.org/governance/council.html). Your feedback is appreciated to help steer the Council activities. As always, if you have specific questions or feedback that you would like to provide, feel free to reach out to your Council representative.
 
-This survey is anonymous, though the Council will see the answers. A summary of these results will be released after the survey is complete.
+This survey is anonymous. The Council will go through all answers and release a summary after the survey is complete.
 
 ## Leadership Council Effectiveness
 

--- a/surveys/micro/leadership-council-2024.md
+++ b/surveys/micro/leadership-council-2024.md
@@ -10,9 +10,31 @@ This survey is anonymous, though the Council will see the answers. A summary of 
 
 Type: select one (optional)
 
+- Strongly Agree
 - Agree
-- Neither agree nor disagree
+- Unsure
 - Disagree
+- Strongly Disagree
+
+### I am aware of the role that the Leadership Council plays in the governance of the Rust Project.
+
+Type: select one (optional)
+
+- Strongly Agree
+- Agree
+- Unsure
+- Disagree
+- Strongly Disagree
+
+### The Rust Project has a solid foundation of Project governance.
+
+Type: select one (optional)
+
+- Strongly Agree
+- Agree
+- Unsure
+- Disagree
+- Strongly Disagree
 
 ### Are there areas of the Leadership Council that you think are going well?
 


### PR DESCRIPTION
This adds a micro-survey for Rust project members to provide feedback on the Leadership Council. This is intended to be sent to `all@rust-lang.org`, and perhaps also post a link in #general.

cc @rust-lang/leadership-council 
