### PR TITLE
Remove question about how often do people do coding/design work

### DIFF
--- a/surveys/2024-annual-survey/questions.md
+++ b/surveys/2024-annual-survey/questions.md
@@ -94,19 +94,6 @@ Type: select one
 > those who program once a week but always in Rust and those who program daily but
 > use Rust once a week.
 
-### On average, how often do you do coding/design work in general?
-
-Type: select one
-
-- Daily or nearly so
-- Weekly or nearly so
-- Monthly or nearly so
-- Rarely
-
-> **justification**
->
-> Could be interesting to understand the *absolute* coding/design experience of the cohort and then compare it with *relative* Rust experience, see comment: https://github.com/rust-lang/surveys/pull/234/files#r1347513327
-
 ### How would you rate your Rust expertise?
 
 Type: select one


### PR DESCRIPTION
This question was originally suggested [here](https://github.com/rust-lang/surveys/pull/234/files#r1347513327).

While I think that the idea wasn't bad, I don't think that this question currently pulls its weight, so I'd like to remove it to shorten the survey. I'm basing this on the following two reasons:
1) This question only makes sense if we would do some complex cohort analysis and separate the answers of individual people. However, while SurveyHero can do this partially, we don't have access to it, and there's currently no automation (frankly, nor anyone who would have the time/motivation) that would help us with it. And without such analysis, this question is IMO not very useful.
2) Last year, we got the following answers:
<img src="https://github.com/user-attachments/assets/d308cbbf-cbde-4c10-9c02-8af74234ffa3" width="400px" />

In short, ~95 % people answered that they do coding or design work daily or weekly. I think that this shows the structure of our audience, that is probably highly technical. I think that we don't need to repeat the same question next time; I don't expect that it will change a lot.

CC @alice-i-cecile