### PR TITLE
Add "Automotive" as an answer for a technology domain

### DIFF
--- a/surveys/2024-annual-survey/questions.md
+++ b/surveys/2024-annual-survey/questions.md
@@ -624,6 +624,7 @@ Type: free form (optional)
 Type: select all that apply (optional)
 
 - Audio programming
+- Automotive
 - Blockchain
 - Cloud computing applications
 - Cloud computing infrastructure or utilities


### PR DESCRIPTION
It had some hits in the previous year's open answers, and given the newly released frameworks, such as Ferrocene, I think it makes sense to include it here.