### PR TITLE
Split macOS into x64 and ARM variants

### DIFF
--- a/surveys/2024-annual-survey/questions.md
+++ b/surveys/2024-annual-survey/questions.md
@@ -161,7 +161,8 @@ Type: select all that apply (optional)
 - Windows 10/11
 - Windows 8 or older
 - Windows Subsystem for Linux
-- macOS
+- macOS (Intel)
+- macOS (ARM)
 - Other (open response)
 
 > **justification**
@@ -186,7 +187,8 @@ Type: select all that apply (optional)
 - Linux (desktop or server)
 - Windows 10/11
 - Windows 8 or older
-- macOS
+- macOS (Intel)
+- macOS (ARM)
 - iOS
 - Android
 - Embedded platforms (with an operating system)


### PR DESCRIPTION
This would tell us more about which of those two common hardware platforms are used the most on macOS. Suggested by @lqd.