### PR TITLE
Clarify answers for Rust job marker for junior/senior role

### DIFF
--- a/surveys/2024-annual-survey/questions.md
+++ b/surveys/2024-annual-survey/questions.md
@@ -693,7 +693,8 @@ Type: matrix (optional)
 
 Statements:
 
-- It is easy for qualified applicants to find jobs that use Rust for the majority of programming
+- It is easy for junior programmers to find jobs that use Rust for the majority of programming
+- It is easy for senior programmers to find jobs that use Rust for the majority of programming
 - Existing Rust jobs are attractive
 
 Rating:


### PR DESCRIPTION
There's not much that we can do with the answers of this question, but this seemed to me like a tiny change that could make the answers a bit more interesting.

No strong feeling about this though, I'm also fine to just keep it as it is.