### PR TITLE
Replace `Rust by Example` with `100 Exercises to Learn Rust`

### DIFF
--- a/surveys/2024-annual-survey/questions.md
+++ b/surveys/2024-annual-survey/questions.md
@@ -141,7 +141,7 @@ Type: select one (optional)
 Type: select all that apply (optional)
 
 - Books ("The Rust Programming Language", "Rust for Rustaceans", etc.)
-- Online exercises (Rustlings, Rust by Example, etc.)
+- Online exercises (Rustlings, 100 Exercises To Learn Rust, etc.)
 - Videos or live-streams
 - Blog posts
 - Documentation


### PR DESCRIPTION
Rust by Example doesn't really contain exercises.

Suggested [here](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Rust.20Annual.20Survey.202024.20RFC.20.28gathering.20feedback.29/near/474108016).