### PR TITLE
Separate `WebAssembly` targets and merge `macOS` targets

### DIFF
--- a/surveys/2024-annual-survey/questions.md
+++ b/surveys/2024-annual-survey/questions.md
@@ -178,8 +178,7 @@ Type: select all that apply (optional)
 - Windows 10/11
 - Windows 8 or older
 - Windows Subsystem for Linux
-- macOS (Intel)
-- macOS (ARM)
+- macOS
 - Other (open response)
 
 > **justification**
@@ -204,13 +203,13 @@ Type: select all that apply (optional)
 - Linux (desktop or server)
 - Windows 10/11
 - Windows 8 or older
-- macOS (Intel)
-- macOS (ARM)
+- macOS
 - iOS
 - Android
 - Embedded platforms (with an operating system)
 - Embedded platforms (bare metal)
-- WebAssembly
+- WebAssembly (for browsers)
+- WebAssembly (for other hosts)
 - Explicitly platform-independent (e.g., a library which does not interact with the operating system)
 - Other (open response)
 


### PR DESCRIPTION
Suggested [here](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/Rust.20Annual.20Survey.202024.20RFC.20.28gathering.20feedback.29/near/474109201). We recently split the macOS platform into two (https://github.com/rust-lang/surveys/pull/281), but since then, we got a new Datadog dashboard that shows us very precisely what are the download counts of individual targets (including macOS Intel/ARM), so I'm sure if we need to split macOS anymore.

CC @lqd