### PR TITLE
Change "rust-lang organization" to "any open-source project"

### DIFF
--- a/surveys/2024-annual-survey/questions.md
+++ b/surveys/2024-annual-survey/questions.md
@@ -509,8 +509,8 @@ Activities:
 - Write, comment on, contribute to discussion of, or provide edits to an open RFC
 - Discuss the Rust project in an official chat or forum (internals.rust-lang.org, Rust Zulip etc.)
 - Open an issue on any repo in the rust-lang GitHub organization
-- Contribute code changes (including tests) to any project in the rust-lang GitHub organization
-- Contribute non-code changes (documentation, comments, etc.) to any project in the rust-lang GitHub organization
+- Contribute code changes (including tests) to any open-source Rust project
+- Contribute non-code changes (documentation, comments, etc.) to any open-source Rust project
 
 Frequency:
 


### PR DESCRIPTION
There's probably no reason why this has to focus on the rust-lang org. Suggested [here](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/Rust.20Annual.20Survey.202024.20RFC.20.28gathering.20feedback.29/near/477427188).