### PR TITLE
Add a draft of Rust Project contributor survey 2025

### DIFF
--- a/surveys/2025/contributor-survey/questions.md
+++ b/surveys/2025/contributor-survey/questions.md
@@ -1,0 +1,83 @@
+# Survey questions
+
+This survey is organized by the Rust Leadership Council. Its goal is to figure out how much Rust Project contributions/work done by Rust Project members is funded vs. how much is volunteer-based. We want to use the results of this survey to secure more funding sources for Rust Project contributions in the future.
+
+This survey is only aimed at Rust Project members. If you are not a member of any Rust team/working group/project group/etc., please do not fill this survey. It is also primarily aimed at "active" contributors, who made at least some contribution in the past 12 months.
+
+Note that when we ask about contributions in this survey, we always mean contributions to the Rust Project repositories, so essentially any repository under the `rust-lang` GitHub organization, plus any other related organizations, such as `rust-lang-nursery`.
+
+### When have you started contributing to the Rust Project?
+
+Type: select one (optional)
+
+- During 2025
+- During 2023 or 2024
+- During 2021 or 2022
+- During 2020 or 2019
+- During 2018 or before
+- I do not contribute to the Rust Project [`NEXT`](<END>)
+
+### How much of your time spent on Rust Project contributions is funded?
+
+Estimate how much of the time that you spend on contributing to the Rust Project is funded. For example, if you spend 20 hours per week contributing, and a company pays you for 10 hours of contributions per week, then approx. 50% of your contribution time is funded.
+
+If you are not funded per-hour, but with a flat rate, attempt to convert the number of received funds to an hourly rate. For example, if you receive $1000 for your Rust Project contributions per month, your normal hourly rate is $100, and you spend 30 hours per month contributing on average, then approx. 33% of your time is funded.
+
+If the ratio changes over time, try to estimate the average ratio over the past 12 months.
+
+Enter the value as an integer percentage, e.g. *50*. If you do not receive any funding for your Rust Project contributions, enter *0* or leave the answer blank.
+
+Type: free form (optional)
+
+### How are you funded for your Rust Project contributions?
+
+Please select all sources of funds that were paid to you **for your Rust Project contributions** in the past 12 months.
+
+If you are not paid for your Rust Project contributions in any way, please skip this question.
+
+Type: select all that apply (optional)
+
+- Employment by a company (I'm paid *primarily* to work on the Rust Project)
+- Employment by a company (work on the Rust Project is an irregular or a side part of my job)
+- Contracting for a company (I'm paid *primarily* to work on the Rust Project)
+- Contracting for a company (work on the Rust Project is an irregular or a side part of my job)
+- Individual sponsors (e.g. GitHub sponsors, Patreon, ...)
+- Grants (e.g. Rust Project Grants, Sovereign Tech Fund, ...)
+- Other (open response)
+
+### Would you appreciate being paid for contributing to the Rust Project?
+
+Type: select one (optional)
+
+- Receiving more funds would allow me to keep my current level of contributions
+- Receiving more funds would allow me to increase my current level of contributions
+- I am happy with the current funding that I have at the moment
+- I do not require/want any funding for my contributions
+
+## Optional detailed questions
+
+The following three questions are OPTIONAL. If you provide answers to them, they will NOT be shared publicly, and will be made available only to the Leadership Council and Rust Foundation staff that facilitates this survey.
+
+### Which companies/organizations fund your contributions to the Rust Project?
+
+If there are more than one, separate them by commas.
+
+**THIS ANSWER IS OPTIONAL**
+
+Type: free form (optional)
+
+### How much money do you receive for your Rust Project contributions per year?
+
+Estimate your average **yearly** income that is specifically being paid for your Rust Project contributions.
+
+Please provide the value in $USD (US Dollars).
+
+**THIS ANSWER IS OPTIONAL**
+
+Type: free form (optional)
+
+### What is your GitHub username?
+
+**THIS ANSWER IS OPTIONAL**
+
+Type: free form (optional)


### PR DESCRIPTION
This is a draft of a survey targeted at Rust Project members, to find out how much of their contribution time is being funded, vs how much of it is volunteer based (https://github.com/rust-lang/leadership-council/issues/222).

Some notes:
- Currently, the survey is only targered at Rust Project *members* (so members of some team/wg/etc., pretty much anyone who was invited to the Rust AllHands), not all Rust Project contributions. The idea is that those are the most people who would appreciate funding the most, as they usually contribute a lot, do a lot of maintenance, non-technical work, etc. But we could also make this open to any Rust Project contributor.
- Currently I describe at the beginning that he survey is only targered to people who contribute to the Rust Project. We don't want other people filling the survey, ofc. We could either rely on people not abusing this, or we could share the link e.g. in a private Zulip channel where there are only members of `t-all` or make the survey password-protected (but then we need to share the password through a similar channel anyway).
- I did not include questions about whether the person is employed or not. I don't think that we need this information? And that the thing that we really care about is how much of their contributions are funded. If someone does Rust work as a volunteer, do we care whether they are a student vs if they are employed?
- I included a set of three personal questions at the end, which could allow us to find out more interesting information about how much money do people receive, which companies are funding them, and then even separate this information across various teams, as we'd also have the user's GH username. If we include these questions, we'd most likely need to run the survey in cooperation with the Rust Foundation. I was told by Paul Lenz that Lori might be able to help us with that.