### PR TITLE
"a organisation" typo fix

### DIFF
--- a/surveys/2025/annual-survey/questions.md
+++ b/surveys/2025/annual-survey/questions.md
@@ -612,7 +612,7 @@ Type: select one
 - My organisation has experimented with Rust or is considering using it
 - My organisation has not seriously considered Rust for any use [`NEXT`](#approximately-how-many-total-developers-does-your-organisation-employ)
 - I am unsure whether my organisation has considered using or currently uses Rust [`NEXT`](#approximately-how-many-total-developers-does-your-organisation-employ)
-- I don't work for a organisation or my organisation does not develop software of any kind [`NEXT`](#please-share-your-assessment-of-the-following-statements-on-rust-employment)
+- I don't work for an organisation or my organisation does not develop software of any kind [`NEXT`](#please-share-your-assessment-of-the-following-statements-on-rust-employment)
 
 > **justification**
 >


### PR DESCRIPTION
was discovered while I was comparing english to russian translation