### PR TITLE
Download question descriptions from SH

### DIFF
--- a/verifier/src/render.rs
+++ b/verifier/src/render.rs
@@ -12,6 +12,9 @@ pub fn render_questions(questions: &[Question], file: &Path) -> io::Result<()> {
     let mut file = std::fs::File::create(file)?;
     for question in questions {
         writeln!(file, "### {}\n", question.text())?;
+        if !question.description_text().is_empty() {
+            writeln!(file, "{}\n", question.description_text())?;
+        }
         match question {
             Question::Input { .. } => {
                 writeln!(file, "Type: free form")?;


### PR DESCRIPTION
This changes the downloader of survey questions so that also the field `description_text` is downloaded.

See its effect in this commit https://github.com/rust-lang/surveys/pull/362/commits/6f57310787c327895e1af1db34c734c67b088fc7

wdyt @Kobzol ?