### PR TITLE
Set a more specific binary name for the verifier tool

### DIFF
--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -3,6 +3,9 @@ name = "verifier"
 version = "0.1.0"
 edition = "2018"
 
+[[bin]]
+name = "rust-survey-verifier"
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
I tend to compile the tooling I use for the Rust project instead of running `cargo run`, I am not fond of giving GB of space away for artifacts.

This little patch change the name of binary artifact of the verifier tool from `verifier` (uh) to `rust-survey-verifier`.

(I'm fine with any other name as long as it's mnemonic, not too generic and less prone to collisions).

p.s. Could probably be an idea establishing a policy for binaries for tools we use internally