### PR TITLE
Improve German translation of 2025 annual survey

### DIFF
--- a/surveys/2025/annual-survey/translations/de.md
+++ b/surveys/2025/annual-survey/translations/de.md
@@ -39,7 +39,7 @@ Type: select all that apply
 - Rust ist zu schwer zu lernen, oder Rust zu lernen würde zu viel Zeit brauchen
 - Community war unhöflich, abweisend, oder auf andere Art unsympathisch
 - Ich benutze lieber eine andere Programmiersprache
-- Ich kann Rust aufgrund externe Umstände nicht nutzen
+- Ich kann Rust aufgrund externer Umstände nicht nutzen
 - Ich hatte noch keine Zeit, Rust zu nutzen
 - Anderer Grund
 
@@ -76,7 +76,7 @@ Type: select one
 - Im Jahr 2023 oder 2024
 - Im Jahr 2021 oder 2022
 - Im Jahr 2019 oder 2020
-- Im Jahr 2016 oder früher
+- Im Jahr 2018 oder früher
 
 ### Wenn Sie Lernmaterial über Rust konsumiert haben, welche Art von Material haben Sie konsumiert?
 
@@ -95,7 +95,7 @@ Type: select all that apply
 - Universitäres Lehrmaterial
 - Sonstiges (bitte angeben)
 
-### Nehmen Sie gerade an einem Kurs oder Training teil, das Rust benutzt oder lehrt? Haben Sie im letzten Jahr an einem solchen Kurs teilgenommen?
+### Nehmen Sie gerade an einem Kurs oder Training teil, das Rust benutzt oder lehrt? Oder haben Sie im letzten Jahr an einem solchen Kurs teilgenommen?
 
 Type: select one
 
@@ -133,7 +133,7 @@ Type: select all that apply
 - iOS
 - Android
 - Embedded Systeme (mit Betriebssystem)
-- Embedded Systeme (bare metal)
+- Embedded Systeme (ohne Betriebssystem)
 - WebAssembly (im Browser)
 - WebAssembly (für andere Zielsysteme)
 - Explizit plattformunabhängig (z.B. ein Crate, das nicht mit dem Betriebssystem interagiert)
@@ -186,7 +186,7 @@ Type: select all that apply
 - Zur Nutzung eines oder mehrerer Sprachfeatures die ich brauche
 - Ich mag es, Zugriff auf die neuesten Features zu haben
 - Um zu helfen, die Nightly Version auf Bugs zu testen
-- Um Design-Feedback zu nächtlichen Funktionen zu geben
+- Um Design-Feedback zu Nightly Funktionen zu geben
 - Um in CI zu testen
 - Eine Crate die ich verwende benötigt Nightly
 - Ein Programm das ich verwende benötigt Nightly
@@ -302,9 +302,9 @@ Type: matrix
 Rows:
 
 - Ich kann die *stabile* Compilerversion aktualisieren, ohne befürchten zu müssen, dass mein Code nicht kompiliert werden kann
-- Ich kann die *nächtliche* Compilerversion aktualisieren, ohne befürchten zu müssen, dass mein Code nicht kompiliert werden kann
+- Ich kann die *Nightly* Compilerversion aktualisieren, ohne befürchten zu müssen, dass mein Code nicht kompiliert werden kann
 - Das Upgrade auf eine neue *stabile* Compilerversion erfordert entweder keine Änderungen oder nur äußerst kleine und einfache Änderungen an meinem Code
-- Das Upgrade auf eine neue *nächtliche* Compilerversion erfordert entweder keine Änderungen oder nur äußerst kleine und einfache Änderungen an meinem Code
+- Das Upgrade auf eine neue *Nightly* Compilerversion erfordert entweder keine Änderungen oder nur äußerst kleine und einfache Änderungen an meinem Code
 
 Columns:
 
@@ -324,9 +324,9 @@ Type: select one
 - Ich weiß es nicht oder es interessiert mich nicht
 - Andere Antwort...
 
-### Welche nicht implementierten oder (nur nächtlichen) Funktionen möchten Sie stabilisieren?
+### Welche nicht implementierten oder (nur Nightly) Funktionen wünschen Sie sich?
 
-Bitte erwähnen Sie hier Funktionen für den *Rust-Compiler*, die sich derzeit hinter einem Feature-Gate befinden (nur verfügbar mit einer instabilen/nächtlichen Veröffentlichung des Rust-Compilers) oder Funktionen, die fehlen und Ihrer Meinung nach für das Rust-Ökosystem oder für Ihre Arbeit von Vorteil wären. Diese Liste schließt andere Tools rund um den Compiler wie Cargo, Rustup, Rustfmt usw. aus.
+Bitte erwähnen Sie hier Funktionen für den *Rust-Compiler oder die Standardbibliothek*, die sich derzeit hinter einem Feature-Gate befinden (nur verfügbar mit einer instabilen/Nightly Veröffentlichung des Rust-Compilers) oder Funktionen, die fehlen und Ihrer Meinung nach für das Rust-Ökosystem oder für Ihre Arbeit von Vorteil wären. Diese Liste schließt andere Tools rund um den Compiler wie Cargo, Rustup, Rustfmt usw. aus.
 
 Bitte wählen Sie nur die Aspekte aus, zu denen Sie eine Meinung haben
 
@@ -345,17 +345,17 @@ Rows:
 - Generische Const-Ausdrücke
 - Const Trait-Methoden
 - Deklarative (macro_rules!) Attribut- (#[attr]) und Derive- (#[derive(Trait)]) Makros
-- Reflektion zur Compilierzeit
+- Reflektion zur Kompilierzeit
 - Variadische Generics
 - Beliebige Self-Typen
 - Enum Varianten Typen
-- Allokator trait, bessere OOM-Verwaltung
+- Allokator Trait, bessere OOM-Verwaltung
 - Stabile ABI
 - ​​​​Portables SIMD
 
 Columns:
 
-- Würde es mir erlauben, Rust zu nutzen
+- Würde ein Hindernis bei meinem Anwendungsfall beseitigen
 - Würde meinen Code verbessern
 - Brauche ich nicht
 - Weiß nicht, was das ist
@@ -373,21 +373,21 @@ Type: matrix
 Rows:
 
 - Logik für Tupel variabler Länge implementieren
-- Quelltext über mehrere crates verteilen (Orphan Rule)
+- Quelltext über mehrere crates verteilen (z.B. Orphan Rule)
 - Iteratoren manuell implementieren
 - Nicht genug in konstanten Funktionen tun können
-- Dynamische Bibliotheken/Plugins implementieren
+- Dynamische Bibliotheken Plugins implementieren
 - Mit anderen Sprachen zusammenarbeiten (z.B. C oder C++)
 - Strukturierte Nebenläufigkeit mit Async Code erreichen
 - Async-Laufzeit-agnostischen Code schreiben
 - Korrekten unsafe Code schreiben
 - ​​​​Der Borrow Checker lehnt meinen validen Code ab
-- ​​​​Schlechte Performance zur Programmlaufzeit
+- Langsame Performance zur Programmlaufzeit
 - Langsame Kompilierung​​​​
 - Große Binärdateien der kompilierten Programme​​​​
-- Hoher Speicherplatzverbrauch (der Dateien im target-Verzeichnis)​​​​
-- Kompilierfehler (z.B. interner Kompilerfehler, auch ICE genannt, oder Fehlkompilationen)
-- Unklare oder undurchsichtige Fehlermeldungen des Kompilers
+- Hoher Speicherplatzverbrauch (z.B. der Dateien im target-Verzeichnis)​​​​
+- Kompilierfehler (z.B. interner Kompilierfehler, auch ICE genannt, oder Fehlkompilationen)
+- Unklare oder undurchsichtige Fehlermeldungen des Compilers
 - Unterdurchschnittliche IDE-Unterstützung (z.B. fehlende Fehlermeldungen oder langsame Analyse)​​​​
 - Unterdurchschnittliche Debugging-Erfahrung (z.B. fehlende Visualisierungen oder async Stacktraces)​​​​
 - Fehlende Dokumentation der Rust Sprache oder Standardbibliothek​​​​
@@ -402,7 +402,7 @@ Columns:
 
 Type: free form
 
-### Welches in den letzten 12 Monaten stabilisierte Feature nutzen Sie am Meisten?
+### Welches in den letzten 12 Monaten stabilisierte Feature nutzen Sie am meisten?
 
 Der Text in Klammern zeigt die Rust-Version an, in der das Feature stabilisiert wurde.
 
@@ -426,7 +426,7 @@ Columns:
 - Ich wusste nicht, dass dies stabilisiert wurde
 - Ich weiß nicht, was das ist
 
-### Wie kompilieren Sie Ihre Rust Projekte?
+### Wie bauen Sie Ihre Rust Projekte?
 
 Sie können mehrere Optionen auswählen.
 
@@ -435,7 +435,7 @@ Type: select all that apply
 - Ich benutze Cargo
 - Ich verwende ein anderes Build-System
 - Ich kombiniere Cargo und ein anderes Build-System
-- Wenn Sie Cargo mit anderen Build-Systemen verwenden (oder einfach nur verwenden), welche verwenden Sie?
+- Wenn Sie Cargo mit anderen Build-Systemen verwenden (oder nur andere verwenden), welche verwenden Sie?
 
 ### Woher beziehen Sie crates, von denen Ihre Rust-Projekte abhängen?
 
@@ -444,7 +444,7 @@ Sie können mehrere Optionen auswählen.
 Type: select all that apply
 
 - Ich verwende crates.io
-- Ich verwende eine benutzerdefinierte/lokale/Firmenregistrierung
+- Ich verwende eine benutzerdefinierte/lokale/Firmen- Registry
 - Ich verwende einen Mirror von crates.io
 - Git Repositories
 - Ich weiß es nicht
@@ -469,14 +469,14 @@ Rows:
 
 - Informationsmaterial über Rust erstellen (z.B. einen Blog schreiben, streamen, YouTube Videos produzieren, auf einer Konferenz präsentieren, …)
 - Informationsmaterial über Rust konsumieren (z.B. eine Artikel lesen, Streams oder Videos schauen, …)
-- Offizielle Kommunikationskanälen lesen (z.B. This Week in Rust, den offizielle Rust Blog, den Twitteraccount von Rust, …)
+- Offizielle Kommunikationskanälen lesen (z.B. This Week in Rust, den offiziellen Rust Blog, den Bluesky Account von Rust, …)
 - An Unterhaltungen auf Social Media über Rust teilnehmen (z.B. auf Hacker News, r/rust, Twitter, LinkedIn, …)
 - Ein Rust Meetup oder eine Konferenz (virtuell oder vor Ort) besuchen
-- Einen RFC schreiben, kommentieren, zu der Diskussion betragen, oder Änderungen an dem RFC vorschlagen
-- Das Rust-Projekt in einem offiziellen Chat besprechen (entweder Zulip oder Discord)
+- Einen RFC schreiben, kommentieren, zu der Diskussion beitragen, oder Änderungen an einem RFC vorschlagen
+- Das Rust-Projekt in einem offiziellen Chat oder Forum besprechen (z.B. internals.rust-lang.org, Rust Zulip, …)
 - Ein Issue in einem beliebigen Repository in der rust-lang GitHub-Organisation eröffnen
-- Code-Änderungen (einschließlich Tests) zu einem beliebigen Projekt in der rust-lang GitHub-Organisation beitragen
-- Nicht-Code-Änderungen (Dokumentation, Kommentare usw.) zu einem Projekt in der rust-lang GitHub-Organisation beitragen
+- Code-Änderungen (einschließlich Tests) zu einem beliebigen Open-Source Rust Projekt beitragen
+- Nicht-Code-Änderungen (Dokumentation, Kommentare usw.) zu einem beliebigen Open-Source Rust Projekt beitragen
 
 Columns:
 
@@ -492,8 +492,8 @@ Type: matrix
 Rows:
 
 - *Offizielle* Rust-Community-Foren oder -Chats (users.rust-lang.org, internals.rust-lang.org, der offizielle Rust Discord oder der Rust Zulip)
-- *Inoffizielle* Rust-Community-Foren oder -Chats (z. B. reddit.com/r/rust, Hacker News, der Rust-Community-Discord usw.)
-- Auf einen bestimmten Bereich spezialisierte Community (z. B. Spieleentwicklung, Audio, usw.)
+- *Inoffizielle* Rust-Community-Foren oder -Chats (z.B. reddit.com/r/rust, Hacker News, der Rust-Community-Discord usw.)
+- Auf einen bestimmten Bereich spezialisierte Community (z.B. Spieleentwicklung, Audio, usw.)
 - An einer Rust-Konferenz teilnehmen
 - An einem Rust-Treffen oder einer lokalen Community-Veranstaltung teilnehmen
 - Diskussionen (Issues, Pull-Requests usw.) in einem Repository *innerhalb* der rust-lang GitHub-Organisation
@@ -521,7 +521,7 @@ Type: select one
 
 Type: select one
 
-- Ja, in erster Linie als einzelner Mitwirkender (dh. Nicht-Manager)
+- Ja, in erster Linie als einzelner Mitwirkender (d.h. Nicht-Manager)
 - Ich manage in erster Linie andere, die es tun
 - Nein
 
@@ -604,7 +604,7 @@ Type: select all that apply
 - Programmiersprachen und zugehörige Programme (einschließlich Compiler, IDEs, Standardbibliotheken usw.)
 - Robotik
 - Wissenschaftliches und/oder numerisches Rechnen
-- Serverseitige oder &quot;Backend&quot;-Anwendung
+- Serverseitige oder "Backend"-Anwendung
 - Simulation
 - Webanwendungs-Frontend
 - WebAssembly
@@ -630,7 +630,7 @@ Type: select one
 
 - Ja
 - Nein (es ist geplant, andere Entwickler einzustellen)
-- Nein (es ist nicht geplant, Entwickler einzustellen)
+- Nein (es ist nicht geplant, generell Entwickler einzustellen)
 - Ich weiß es nicht
 
 ### Stimmen Sie den folgenden Aussagen zum Arbeitsmarkt für Rust zu?
@@ -677,8 +677,8 @@ Type: select all that apply
 - Instabilität der Sprache
 - Von einer Alternative abgelöst
 - Wird zu komplex
-- Hilfsprogramme und Dokumentation sind nicht ausreichend zugänglich (z. B. aufgrund von Sprache oder Inkompatibilität mit Bildschirmleseprogrammen)
-- Die Rust Foundation unterstützt das Rust-Projekt nicht ordnungsgemäß (z. B. in finanzieller, infrastruktureller oder rechtlicher Hinsicht)
+- Hilfsprogramme und Dokumentation sind nicht ausreichend zugänglich (z.B. aufgrund von Sprache oder Inkompatibilität mit Bildschirmleseprogrammen)
+- Die Rust Foundation unterstützt das Rust-Projekt nicht ordnungsgemäß (z.B. in finanzieller, infrastruktureller oder rechtlicher Hinsicht)
 - Die Projektplaner passen sich nicht der Größe/den Anforderungen der Community an
 - Entwickler/Betreuer der Sprache werden nicht richtig unterstützt
 - Ich mache mir keine Sorgen
@@ -705,7 +705,7 @@ Type: select all that apply
 - Nicht-binäres Geschlecht
 - Älter oder jünger als die durchschnittlichen Entwickler, die ich kenne
 - Politische Ansichten
-- Rasse oder ethnische Minderheit
+- Ethnische Herkunft
 - Religiöse Ansichten
 - Trans
 - Frau oder als Frau wahrgenommen
@@ -723,7 +723,7 @@ Type: select one
 - Ja, in einem berufsbildenden Programm
 - Ja, andere
 
-### Wie lange programmieren Sie schon (in jeder Sprache, aus welchem Grund auch immer)?
+### Wie lange programmieren Sie schon (in einer beliebigen Sprache, aus welchem Grund auch immer)?
 
 Type: select one
 
@@ -938,7 +938,7 @@ Type: select one
 - Äthiopien
 - Österreich
 
-### Wenn Sie "Ein anderes Land" aus der obigen Länderliste ausgewählt haben, geben Sie bitte unten Ihr Wohnsitzgebiet ein:
+### Da Sie "Ein anderes Land" aus der obigen Länderliste ausgewählt haben, geben Sie bitte unten Ihr Wohnsitzgebiet ein:
 
 Type: free form
 
@@ -948,13 +948,13 @@ Sie können mehrere Optionen auswählen.
 
 Type: select all that apply
 
-- Ich fühle mich wohl und in der Lage, ein gesprochenes technisches Gespräch auf Englisch zu führen
+- Ich fühle mich wohl und in der Lage, ein gesprochenes Fachgespräch auf Englisch zu führen
 - Ich fühle mich wohl und in der Lage, ein schriftliches Fachgespräch auf Englisch zu führen
 - Ich fühle mich wohl und in der Lage, technische Dokumentationen auf Englisch zu lesen
-- Ich fühle mich wohl und in der Lage, einen technischen Vortrag (z. B. bei einer Konferenz oder einem Treffen) auf Englisch zu hören
-- Ich fühle mich wohl und in der Lage, schriftliches technisches Lehrmaterial (z. B. Fachbücher, Blog-Posts usw.) auf Englisch zu lesen
+- Ich fühle mich wohl und in der Lage, einen technischen Vortrag (z.B. bei einer Konferenz oder einem Treffen) auf Englisch zu hören
+- Ich fühle mich wohl und in der Lage, schriftliches technisches Lehrmaterial (z.B. Fachbücher, Blog-Posts usw.) auf Englisch zu lesen
 
-### Welche Sprache(n) bevorzugten Sie, um technische Inhalte zu konsumieren (z.B. Blogs, Dokumentation, usw.)
+### Welche Sprache(n) bevorzugen Sie, um technische Inhalte zu konsumieren (z.B. Blogs, Dokumentation, usw.)?
 
 WICHTIG: Ihre Antwort sollte Ihre Präferenz widerspiegeln und nicht das, was Sie sprachlich beherrschen. Wenn Sie beispielsweise ohne Schwierigkeiten technische Kommunikation sowohl auf Englisch als auch auf Koreanisch lesen können, Sie aber immer Koreanisch bevorzugen, sollten Sie nur Koreanisch als Ihre Präferenz angeben.
 


### PR DESCRIPTION
Changes:
- Re-applies #322, apparently that was not taken over (hopefully it is for the 2026+ translations)
- Fix typos & grammar issues
- Fix inconsistencies regarding ["Compiler" / "Kompilierer"](https://de.wikipedia.org/wiki/Compiler); 'C' and 'K' were mixed up for the words
Usage is still not consistent in the translation now, but I guess this inconsistency is fine (unless you want to fully replace "Compiler" with "Kompilierer"), since at least the verb ("kompilieren") and noun describing the process ("Kompilierung") have to use a 'k' in German.
- Fix inconsistencies with the English questions