### PR TITLE
Add `explicit_tail_calls` as an option for wanted features

### DIFF
--- a/surveys/2025/annual-survey/questions.md
+++ b/surveys/2025/annual-survey/questions.md
@@ -376,6 +376,7 @@ Features:
 - [Allocator trait and better OOM handling](https://github.com/rust-lang/rust/issues/32838)
 - [Stable ABI](https://github.com/rust-lang/rust/issues/111423)
 - [Portable SIMD](https://github.com/rust-lang/portable-simd)
+- [Explicit Tail Calls](https://github.com/rust-lang/rust/issues/112788)
 
 Priority:
 


### PR DESCRIPTION
This year the experimental `explicit_tail_calls` feature has made its way to the nightly channel. As of 23 November 2025, [the draft RFC](https://github.com/rust-lang/rfcs/pull/3407) has attracted 128 upvotes, 27 hearts, 27 rockets and so on, indicating a high degree of desirability. This PR serves to include this popular feature as an option in the upcoming annual survey.