### PR TITLE
Implement support for parsing open answers directly

### DIFF
--- a/report/surveyhero/parser.py
+++ b/report/surveyhero/parser.py
@@ -2,12 +2,16 @@ import csv
 import re
 from collections import defaultdict
 from pathlib import Path
+from typing import Optional
+
+import pandas as pd
 
 from .survey import SurveyFullAnswers, Question, MatrixQuestion, Answer, SimpleQuestion, \
     SurveyReport, RatingQuestion, RatingAnswer
 
 
-def parse_surveyhero_answers(path: Path, year: int) -> SurveyFullAnswers:
+def parse_surveyhero_answers(path: Path, year: int,
+                             summary: Optional[SurveyReport] = None) -> SurveyFullAnswers:
     """
     Parses the full CSV from SurveyHero,
     which contains all responses from individual respondents (except
@@ -30,7 +34,9 @@ def parse_surveyhero_answers(path: Path, year: int) -> SurveyFullAnswers:
         year=year,
         answers=answers,
         questions=questions,
-        total_respondents=total_respondents
+        total_respondents=total_respondents,
+        df=pd.read_csv(path),
+        summary=summary
     )
 
 

--- a/report/surveyhero/utils.py
+++ b/report/surveyhero/utils.py
@@ -1,5 +1,7 @@
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Any
+
+import numpy as np
 
 from .survey import SurveyReport, SurveyFullAnswers
 
@@ -32,3 +34,7 @@ def print_answer_index(answers: SurveyFullAnswers, report: SurveyReport, path: P
             if any(question == q.question for q in report.questions) and index > 0:
                 print(file=f)
             print(f"{index}: {question}", file=f)
+
+
+def is_nan(value: Any) -> bool:
+    return isinstance(value, float) and np.isnan(value)


### PR DESCRIPTION
A bunch of script improvements I did in 2025 for generating charts for the contributor survey (not published yet). The main new thing is that we now parse the full SurveyHero answers (rather than just the aggregated summary), and base the charts on that. That means that we can do charts that slice the data, e.g. "Show answers to question B categorized by answers to question A", which wasn't previously easily doable.
