### PR TITLE
Add the 2026 Debugging Survey

### DIFF
--- a/surveys/2026/debugging/questions.md
+++ b/surveys/2026/debugging/questions.md
@@ -30,9 +30,9 @@ Type: select one
 
 Type: select one
 
-- Yes [`NEXT`](#what-tools-do-you-use-to-debug-rust-programs-on-which-operating-systems)
-- No, I don't currently use debuggers in Rust, but I have in the past [`NEXT`](#what-tools-do-you-use-to-debug-rust-programs-on-which-operating-systems)
-- No, I have never used debuggers in Rust [`NEXT`](#do-you-use-debuggers-in-other-programming-languages)
+- Yes [`NEXT`](#what-tools-and-workflows-do-you-use-to-debug-rust-programs-on-which-operating-systems)
+- No, I don't currently use debuggers in Rust, but I have in the past [`NEXT`](#what-tools-and-workflows-do-you-use-to-debug-rust-programs-on-which-operating-systems)
+- No, I have never used debuggers in Rust [`NEXT`](#what-tools-and-workflows-do-you-use-to-debug-rust-programs-on-which-operating-systems)
 
 ### Did you use debuggers in Rust?
 
@@ -45,8 +45,8 @@ Type: select one
 
 Type: select one
 
-- Yes [`NEXT`](#what-tools-do-you-use-to-debug-rust-programs-on-which-operating-systems)
-- No, but they were one of the reasons why I stopped using Rust [`NEXT`](#what-tools-do-you-use-to-debug-rust-programs-on-which-operating-systems)
+- Yes [`NEXT`](#what-tools-and-workflows-do-you-use-to-debug-rust-programs-on-which-operating-systems)
+- No, but they were one of the reasons why I stopped using Rust [`NEXT`](#what-tools-and-workflows-do-you-use-to-debug-rust-programs-on-which-operating-systems)
 - No [`NEXT`](#is-there-anything-else-you-would-like-to-tell-us-about-debugging-support-in-rust)
 
 ### Do you use debuggers in other programming languages?


### PR DESCRIPTION
Adds a quick survey about debugging support in Rust. The goal is to understand how Rustaceans use debuggers when working with Rust, what pain points they face, and what can be done to improve the experience.

The survey features 18 possible questions based on initial feedback from @Walnut356 and people in `#t-compiler` on Zulip.