### PR TITLE
chore: Ignore various secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ answers.txt
 __pycache__/
 /data/
 .env
+/open_responses/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 answers.txt
 __pycache__/
 /data/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 answers.txt
 __pycache__/
+/data/


### PR DESCRIPTION
While working on #407, I've noticed I have a lot of files showing up in my `git status` that I have no desire to check in. These are mostly files we'd like to avoid checking in at all, from what I can tell. I think we're not taking advantage of `.gitignore` to the degree we ought to. The proposed changes are to ignore:

- `/data/`, the directory that seems to be where raw survey response data goes by convention.
- `.env`, files generally meant for local configuration and secrets. We have a sample checked in which suggests that some of us do use `.env` files to store API tokens.

In addition, I'd also like to suggest we ignore any or all of:

- `open-response-*.txt`, the pattern I used in #407 to make it easier to read multiple open response answers. We already ignore `answers.txt`, but this pattern is more flexible. We could also consider `open-response-*.*` as an alternative, to account for the possibility of using a different format in the future, such as markdown.
- `*.secret.*`, a pattern I have used in my own projects to make it easy to ignore a file without needing to change my `.gitignore` or even reveal the existence of said file. This allows `foo.bar` to be ignored by renaming it to `foo.secret.bar`.

I expect these additional suggestions to be slightly more controversial, and have not yet made the changes. Pending discussion.